### PR TITLE
Use model binding for parameters

### DIFF
--- a/toofz.NecroDancer.Web.Api.Tests/ContextUtil.cs
+++ b/toofz.NecroDancer.Web.Api.Tests/ContextUtil.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+// Copyright(c) Microsoft Open Technologies, Inc.All rights reserved.
+// Microsoft Open Technologies would like to thank its contributors, a list
+// of whom are at http://aspnetwebstack.codeplex.com/wikipage?title=Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you
+// may not use this file except in compliance with the License. You may
+// obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing permissions
+// and limitations under the License.
+
+using System.Net.Http;
+using System.Web.Http.Controllers;
+using System.Web.Http.Filters;
+using System.Web.Http.Routing;
+using Moq;
+
+namespace System.Web.Http
+{
+    internal static class ContextUtil
+    {
+        public static HttpControllerContext CreateControllerContext(HttpConfiguration configuration = null, IHttpController instance = null, IHttpRouteData routeData = null, HttpRequestMessage request = null)
+        {
+            HttpConfiguration config = configuration ?? new HttpConfiguration();
+            IHttpRouteData route = routeData ?? new HttpRouteData(new HttpRoute());
+            HttpRequestMessage req = request ?? new HttpRequestMessage();
+            req.SetConfiguration(config);
+            req.SetRouteData(route);
+
+            HttpControllerContext context = new HttpControllerContext(config, route, req);
+            if (instance != null)
+            {
+                context.Controller = instance;
+            }
+            context.ControllerDescriptor = CreateControllerDescriptor(config);
+
+            return context;
+        }
+
+        public static HttpActionContext CreateActionContext(HttpControllerContext controllerContext = null, HttpActionDescriptor actionDescriptor = null)
+        {
+            HttpControllerContext context = controllerContext ?? ContextUtil.CreateControllerContext();
+            HttpActionDescriptor descriptor = actionDescriptor ?? CreateActionDescriptor();
+            descriptor.ControllerDescriptor = context.ControllerDescriptor;
+            return new HttpActionContext(context, descriptor);
+        }
+
+        public static HttpActionContext GetHttpActionContext(HttpRequestMessage request)
+        {
+            HttpActionContext actionContext = CreateActionContext();
+            actionContext.ControllerContext.Request = request;
+            return actionContext;
+        }
+
+        public static HttpActionExecutedContext GetActionExecutedContext(HttpRequestMessage request, HttpResponseMessage response)
+        {
+            HttpActionContext actionContext = CreateActionContext();
+            actionContext.ControllerContext.Request = request;
+            HttpActionExecutedContext actionExecutedContext = new HttpActionExecutedContext(actionContext, null) { Response = response };
+            return actionExecutedContext;
+        }
+
+        public static HttpControllerDescriptor CreateControllerDescriptor(HttpConfiguration config = null)
+        {
+            if (config == null)
+            {
+                config = new HttpConfiguration();
+            }
+            return new HttpControllerDescriptor() { Configuration = config, ControllerName = "FooController" };
+        }
+
+        public static HttpActionDescriptor CreateActionDescriptor()
+        {
+            var mock = new Mock<HttpActionDescriptor>() { CallBase = true };
+            mock.SetupGet(d => d.ActionName).Returns("Bar");
+            return mock.Object;
+        }
+    }
+}

--- a/toofz.NecroDancer.Web.Api.Tests/Controllers/EnemiesControllerTests.cs
+++ b/toofz.NecroDancer.Web.Api.Tests/Controllers/EnemiesControllerTests.cs
@@ -27,7 +27,7 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
                 var controller = new EnemiesController(mockRepository.Object);
 
                 // Act
-                var enemiesDTO = await controller.GetEnemiesAsync(null, new EnemiesPagination(), CancellationToken.None);
+                var enemiesDTO = await controller.GetEnemiesAsync(new EnemiesPagination(), null, CancellationToken.None);
 
                 // Assert
                 Assert.IsInstanceOfType(enemiesDTO, typeof(Enemies));
@@ -73,7 +73,7 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
                 var controller = new EnemiesController(mockRepository.Object);
 
                 // Act
-                var actionResult = await controller.GetEnemies(null, new EnemiesPagination());
+                var actionResult = await controller.GetEnemies(new EnemiesPagination(), null);
                 var contentResult = actionResult as OkNegotiatedContentResult<Enemies>;
 
                 // Assert

--- a/toofz.NecroDancer.Web.Api.Tests/Controllers/EnemiesControllerTests.cs
+++ b/toofz.NecroDancer.Web.Api.Tests/Controllers/EnemiesControllerTests.cs
@@ -3,9 +3,9 @@ using System.Threading.Tasks;
 using System.Web.Http.Results;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using toofz.NecroDancer.Data;
 using toofz.NecroDancer.EntityFramework;
 using toofz.NecroDancer.Web.Api.Controllers;
+using toofz.NecroDancer.Web.Api.Models;
 using toofz.TestsShared;
 
 namespace toofz.NecroDancer.Web.Api.Tests.Controllers
@@ -19,7 +19,7 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
             public async Task GetEnemiesAsync_ReturnsEnemiesDTO()
             {
                 // Arrange
-                var mockSet = MockHelper.MockSet<Enemy>();
+                var mockSet = MockHelper.MockSet<Data.Enemy>();
 
                 var mockRepository = new Mock<NecroDancerContext>();
                 mockRepository.Setup(x => x.Enemies).Returns(mockSet.Object);
@@ -27,10 +27,10 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
                 var controller = new EnemiesController(mockRepository.Object);
 
                 // Act
-                var enemiesDTO = await controller.GetEnemiesAsync(null, new Models.EnemiesPagination(), CancellationToken.None);
+                var enemiesDTO = await controller.GetEnemiesAsync(null, new EnemiesPagination(), CancellationToken.None);
 
                 // Assert
-                Assert.IsInstanceOfType(enemiesDTO, typeof(Models.Enemies));
+                Assert.IsInstanceOfType(enemiesDTO, typeof(Enemies));
             }
         }
 
@@ -41,7 +41,7 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
             public async Task ReturnsOk()
             {
                 // Arrange
-                var mockSet = MockHelper.MockSet<Enemy>();
+                var mockSet = MockHelper.MockSet<Data.Enemy>();
 
                 var mockRepository = new Mock<NecroDancerContext>();
                 mockRepository.Setup(x => x.Enemies).Returns(mockSet.Object);
@@ -49,8 +49,8 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
                 var controller = new EnemiesController(mockRepository.Object);
 
                 // Act
-                var actionResult = await controller.GetEnemies(new Models.EnemiesPagination());
-                var contentResult = actionResult as OkNegotiatedContentResult<Models.Enemies>;
+                var actionResult = await controller.GetEnemies(new EnemiesPagination());
+                var contentResult = actionResult as OkNegotiatedContentResult<Enemies>;
 
                 // Assert
                 Assert.IsNotNull(contentResult);
@@ -65,7 +65,7 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
             public async Task ReturnsOk()
             {
                 // Arrange
-                var mockSet = MockHelper.MockSet<Enemy>();
+                var mockSet = MockHelper.MockSet<Data.Enemy>();
 
                 var mockRepository = new Mock<NecroDancerContext>();
                 mockRepository.Setup(x => x.Enemies).Returns(mockSet.Object);
@@ -73,8 +73,8 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
                 var controller = new EnemiesController(mockRepository.Object);
 
                 // Act
-                var actionResult = await controller.GetEnemies(null, new Models.EnemiesPagination());
-                var contentResult = actionResult as OkNegotiatedContentResult<Models.Enemies>;
+                var actionResult = await controller.GetEnemies(null, new EnemiesPagination());
+                var contentResult = actionResult as OkNegotiatedContentResult<Enemies>;
 
                 // Assert
                 Assert.IsNotNull(contentResult);

--- a/toofz.NecroDancer.Web.Api.Tests/Controllers/LeaderboardsControllerTests.cs
+++ b/toofz.NecroDancer.Web.Api.Tests/Controllers/LeaderboardsControllerTests.cs
@@ -32,7 +32,7 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
                 var products = new Products(new Category());
 
                 // Act
-                var actionResult = await controller.GetDailies(products, null);
+                var actionResult = await controller.GetDailies(new LeaderboardsPagination(), products);
 
                 // Assert
                 Assert.IsInstanceOfType(actionResult, typeof(OkNegotiatedContentResult<DailyLeaderboards>));
@@ -63,7 +63,7 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
                     LeaderboardsResources.ReadLeaderboardHeaders());
 
                 // Act
-                var actionResult = await controller.GetLeaderboardEntries(741312, new LeaderboardsPagination());
+                var actionResult = await controller.GetLeaderboardEntries(new LeaderboardsPagination(), 741312);
                 var contentResult = actionResult as OkNegotiatedContentResult<LeaderboardEntries>;
 
                 // Assert
@@ -86,7 +86,7 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
                     LeaderboardsResources.ReadLeaderboardHeaders());
 
                 // Act
-                var actionResult = await controller.GetLeaderboardEntries(0, new LeaderboardsPagination());
+                var actionResult = await controller.GetLeaderboardEntries(new LeaderboardsPagination(), 0);
 
                 // Assert
                 Assert.IsInstanceOfType(actionResult, typeof(NotFoundResult));

--- a/toofz.NecroDancer.Web.Api.Tests/Controllers/LeaderboardsControllerTests.cs
+++ b/toofz.NecroDancer.Web.Api.Tests/Controllers/LeaderboardsControllerTests.cs
@@ -5,6 +5,7 @@ using Moq;
 using toofz.NecroDancer.Leaderboards;
 using toofz.NecroDancer.Leaderboards.EntityFramework;
 using toofz.NecroDancer.Web.Api.Controllers;
+using toofz.NecroDancer.Web.Api.Models;
 using toofz.TestsShared;
 
 namespace toofz.NecroDancer.Web.Api.Tests.Controllers
@@ -18,21 +19,23 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
             public async Task ReturnsOk()
             {
                 // Arrange
-                var mockSetDailyLeaderboard = MockHelper.MockSet<DailyLeaderboard>();
+                var mockSetDailyLeaderboard = MockHelper.MockSet<Leaderboards.DailyLeaderboard>();
 
                 var mockRepository = new Mock<LeaderboardsContext>();
                 mockRepository.Setup(x => x.DailyLeaderboards).Returns(mockSetDailyLeaderboard.Object);
 
                 var controller = new LeaderboardsController(
                     mockRepository.Object,
-                    LeaderboardsResources.ReadLeaderboardCategories(),
-                    LeaderboardsResources.ReadLeaderboardHeaders());
+                    new Categories(),
+                    new LeaderboardHeaders());
+
+                var products = new Products(new Category());
 
                 // Act
-                var actionResult = await controller.GetDailies(null);
+                var actionResult = await controller.GetDailies(products, null);
 
                 // Assert
-                Assert.IsInstanceOfType(actionResult, typeof(OkNegotiatedContentResult<Models.DailyLeaderboards>));
+                Assert.IsInstanceOfType(actionResult, typeof(OkNegotiatedContentResult<DailyLeaderboards>));
             }
         }
 
@@ -43,11 +46,11 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
             public async Task ReturnsOk()
             {
                 // Arrange
-                var mockLeaderboardSet = MockHelper.MockSet(new Leaderboard { LeaderboardId = 741312 });
+                var mockLeaderboardSet = MockHelper.MockSet(new Leaderboards.Leaderboard { LeaderboardId = 741312 });
 
-                var mockEntrySet = MockHelper.MockSet<Entry>();
+                var mockEntrySet = MockHelper.MockSet<Leaderboards.Entry>();
 
-                var mockReplaySet = MockHelper.MockSet<Replay>();
+                var mockReplaySet = MockHelper.MockSet<Leaderboards.Replay>();
 
                 var mockRepository = new Mock<LeaderboardsContext>();
                 mockRepository.Setup(x => x.Leaderboards).Returns(mockLeaderboardSet.Object);
@@ -60,19 +63,19 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
                     LeaderboardsResources.ReadLeaderboardHeaders());
 
                 // Act
-                var actionResult = await controller.GetLeaderboardEntries(741312, new Models.LeaderboardsPagination());
-                var contentResult = actionResult as OkNegotiatedContentResult<Models.LeaderboardEntries>;
+                var actionResult = await controller.GetLeaderboardEntries(741312, new LeaderboardsPagination());
+                var contentResult = actionResult as OkNegotiatedContentResult<LeaderboardEntries>;
 
                 // Assert
                 Assert.IsNotNull(contentResult);
-                Assert.IsInstanceOfType(contentResult, typeof(OkNegotiatedContentResult<Models.LeaderboardEntries>));
+                Assert.IsInstanceOfType(contentResult, typeof(OkNegotiatedContentResult<LeaderboardEntries>));
             }
 
             [TestMethod]
             public async Task ReturnsNotFound()
             {
                 // Arrange
-                var mockLeaderboardSet = MockHelper.MockSet(new Leaderboard { LeaderboardId = 22 });
+                var mockLeaderboardSet = MockHelper.MockSet(new Leaderboards.Leaderboard { LeaderboardId = 22 });
 
                 var mockRepository = new Mock<LeaderboardsContext>();
                 mockRepository.Setup(x => x.Leaderboards).Returns(mockLeaderboardSet.Object);
@@ -83,7 +86,7 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
                     LeaderboardsResources.ReadLeaderboardHeaders());
 
                 // Act
-                var actionResult = await controller.GetLeaderboardEntries(0, new Models.LeaderboardsPagination());
+                var actionResult = await controller.GetLeaderboardEntries(0, new LeaderboardsPagination());
 
                 // Assert
                 Assert.IsInstanceOfType(actionResult, typeof(NotFoundResult));

--- a/toofz.NecroDancer.Web.Api.Tests/Controllers/PlayersControllerTests.cs
+++ b/toofz.NecroDancer.Web.Api.Tests/Controllers/PlayersControllerTests.cs
@@ -33,7 +33,7 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
                     LeaderboardsResources.ReadLeaderboardHeaders());
 
                 // Act
-                var actionResult = await controller.GetPlayers("", new PlayersPagination());
+                var actionResult = await controller.GetPlayers(new PlayersPagination());
                 var contentResult = actionResult as OkNegotiatedContentResult<Players>;
 
                 // Assert

--- a/toofz.NecroDancer.Web.Api.Tests/Controllers/PlayersControllerTests.cs
+++ b/toofz.NecroDancer.Web.Api.Tests/Controllers/PlayersControllerTests.cs
@@ -6,6 +6,7 @@ using Moq;
 using toofz.NecroDancer.Leaderboards;
 using toofz.NecroDancer.Leaderboards.EntityFramework;
 using toofz.NecroDancer.Web.Api.Controllers;
+using toofz.NecroDancer.Web.Api.Models;
 using toofz.TestsShared;
 
 namespace toofz.NecroDancer.Web.Api.Tests.Controllers
@@ -19,7 +20,7 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
             public async Task NoParams_ReturnsPlayers()
             {
                 // Arrange
-                var mockSet = MockHelper.MockSet<Player>();
+                var mockSet = MockHelper.MockSet<Leaderboards.Player>();
 
                 var mockRepository = new Mock<LeaderboardsContext>();
                 mockRepository.Setup(x => x.Players).Returns(mockSet.Object);
@@ -32,8 +33,8 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
                     LeaderboardsResources.ReadLeaderboardHeaders());
 
                 // Act
-                var actionResult = await controller.GetPlayers("", new Models.PlayersPagination());
-                var contentResult = actionResult as OkNegotiatedContentResult<Models.Players>;
+                var actionResult = await controller.GetPlayers("", new PlayersPagination());
+                var contentResult = actionResult as OkNegotiatedContentResult<Players>;
 
                 // Assert
                 Assert.IsNotNull(contentResult);
@@ -48,9 +49,9 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
             public async Task ValidParams_ReturnsPlayerEntries()
             {
                 // Arrange
-                var mockSetPlayer = MockHelper.MockSet(new Player { SteamId = 76561197960481221 });
-                var mockSetEntry = MockHelper.MockSet<Entry>();
-                var mockSetReplay = MockHelper.MockSet<Replay>();
+                var mockSetPlayer = MockHelper.MockSet(new Leaderboards.Player { SteamId = 76561197960481221 });
+                var mockSetEntry = MockHelper.MockSet<Leaderboards.Entry>();
+                var mockSetReplay = MockHelper.MockSet<Leaderboards.Replay>();
 
                 var mockRepository = new Mock<LeaderboardsContext>();
                 mockRepository.Setup(x => x.Players).Returns(mockSetPlayer.Object);
@@ -66,8 +67,8 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
 
                 // Act
                 var actionResult = await controller.GetPlayer(76561197960481221);
-                Assert.IsInstanceOfType(actionResult, typeof(OkNegotiatedContentResult<Models.PlayerEntries>));
-                var contentResult = actionResult as OkNegotiatedContentResult<Models.PlayerEntries>;
+                Assert.IsInstanceOfType(actionResult, typeof(OkNegotiatedContentResult<PlayerEntries>));
+                var contentResult = actionResult as OkNegotiatedContentResult<PlayerEntries>;
 
                 // Assert
                 Assert.IsNotNull(contentResult);
@@ -92,8 +93,8 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
                     LeaderboardsResources.ReadLeaderboardHeaders());
 
                 // Act
-                var actionResult = await controller.PostPlayers(new List<Models.PlayerModel>());
-                var contentResult = actionResult as OkNegotiatedContentResult<Models.BulkStore>;
+                var actionResult = await controller.PostPlayers(new List<PlayerModel>());
+                var contentResult = actionResult as OkNegotiatedContentResult<BulkStore>;
 
                 // Assert
                 Assert.IsNotNull(contentResult);
@@ -115,7 +116,7 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
                 controller.ModelState.AddModelError("fakeError", "fakeError");
 
                 // Act
-                var actionResult = await controller.PostPlayers(new List<Models.PlayerModel>());
+                var actionResult = await controller.PostPlayers(new List<PlayerModel>());
 
                 // Assert
                 Assert.IsInstanceOfType(actionResult, typeof(InvalidModelStateResult));

--- a/toofz.NecroDancer.Web.Api.Tests/Controllers/ReplaysControllerTests.cs
+++ b/toofz.NecroDancer.Web.Api.Tests/Controllers/ReplaysControllerTests.cs
@@ -6,6 +6,7 @@ using Moq;
 using toofz.NecroDancer.Leaderboards;
 using toofz.NecroDancer.Leaderboards.EntityFramework;
 using toofz.NecroDancer.Web.Api.Controllers;
+using toofz.NecroDancer.Web.Api.Models;
 using toofz.TestsShared;
 
 namespace toofz.NecroDancer.Web.Api.Tests.Controllers
@@ -19,7 +20,7 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
             public async Task ReturnsOk()
             {
                 // Arrange
-                var mockSet = MockHelper.MockSet<Replay>();
+                var mockSet = MockHelper.MockSet<Leaderboards.Replay>();
 
                 var mockRepository = new Mock<LeaderboardsContext>();
                 mockRepository
@@ -32,7 +33,7 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
 
                 // Act
                 var actionResult = await controller.GetReplays(0);
-                var contentResult = actionResult as OkNegotiatedContentResult<Models.Replays>;
+                var contentResult = actionResult as OkNegotiatedContentResult<Api.Models.Replays>;
 
                 // Assert
                 Assert.IsNotNull(contentResult);
@@ -54,8 +55,8 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
                 var controller = new ReplaysController(mockRepository.Object, mockILeaderboardsStoreClient.Object);
 
                 // Act
-                var actionResult = await controller.PostReplays(new List<Models.ReplayModel>());
-                var contentResult = actionResult as OkNegotiatedContentResult<Models.BulkStore>;
+                var actionResult = await controller.PostReplays(new List<ReplayModel>());
+                var contentResult = actionResult as OkNegotiatedContentResult<BulkStore>;
 
                 // Assert
                 Assert.IsNotNull(contentResult);
@@ -74,7 +75,7 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
                 controller.ModelState.AddModelError("fakeError", "fakeError");
 
                 // Act
-                var actionResult = await controller.PostReplays(new List<Models.ReplayModel>());
+                var actionResult = await controller.PostReplays(new List<ReplayModel>());
 
                 // Assert
                 Assert.IsInstanceOfType(actionResult, typeof(InvalidModelStateResult));

--- a/toofz.NecroDancer.Web.Api.Tests/Controllers/ReplaysControllerTests.cs
+++ b/toofz.NecroDancer.Web.Api.Tests/Controllers/ReplaysControllerTests.cs
@@ -32,7 +32,7 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
                 var controller = new ReplaysController(mockRepository.Object, mockILeaderboardsStoreClient.Object);
 
                 // Act
-                var actionResult = await controller.GetReplays(0);
+                var actionResult = await controller.GetReplays(new ReplaysPagination());
                 var contentResult = actionResult as OkNegotiatedContentResult<Api.Models.Replays>;
 
                 // Assert

--- a/toofz.NecroDancer.Web.Api.Tests/Infrastructure/LeaderboardCategoryBindersTests.cs
+++ b/toofz.NecroDancer.Web.Api.Tests/Infrastructure/LeaderboardCategoryBindersTests.cs
@@ -1,0 +1,121 @@
+﻿using System.Globalization;
+using System.Linq;
+using System.Web.Http.Metadata.Providers;
+using System.Web.Http.ModelBinding;
+using System.Web.Http.ValueProviders;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using toofz.NecroDancer.Leaderboards;
+using toofz.NecroDancer.Web.Api.Models;
+using toofz.NecroDancer.Web.Api.Tests.Models;
+
+namespace toofz.NecroDancer.Web.Api.Tests.Infrastructure
+{
+    class LeaderboardCategoryBaseBinderTests
+    {
+        [TestClass]
+        public class BindModel
+        {
+            const string modelName = "mockModelName";
+            Category category;
+            MockLeaderboardCategoryBaseBinder binder;
+            ModelBindingContext bindingContext;
+            Mock<IValueProvider> mock_ValueProvider;
+
+            [TestInitialize]
+            public void Initialize()
+            {
+                category = new Category
+                {
+                    { "item1", new CategoryItem() },
+                    { "item2", new CategoryItem() },
+                    { "item3", new CategoryItem() },
+                };
+                var model = new MockLeaderboardCategoryBase(category);
+                binder = new MockLeaderboardCategoryBaseBinder(model);
+
+                var data = new EmptyModelMetadataProvider();
+                var modelMetadata = data.GetMetadataForType(null, typeof(LeaderboardCategoryBase));
+                mock_ValueProvider = new Mock<IValueProvider>();
+                bindingContext = new ModelBindingContext
+                {
+                    ModelName = modelName,
+                    ValueProvider = mock_ValueProvider.Object,
+                    ModelMetadata = modelMetadata,
+                };
+            }
+
+            [TestMethod]
+            public void ValueIsNull_SetsModelWithAllValuesAndReturnsTrue()
+            {
+                // Arrange
+                mock_ValueProvider
+                    .Setup(v => v.GetValue(modelName))
+                    .Returns((ValueProviderResult)null);
+
+                // Act
+                var canBind = binder.BindModel(null, bindingContext);
+
+                // Assert
+                Assert.IsInstanceOfType(bindingContext.Model, typeof(LeaderboardCategoryBase));
+                var model = (LeaderboardCategoryBase)bindingContext.Model;
+                Assert.AreEqual(3, model.Count());
+                Assert.IsTrue(canBind);
+            }
+
+            [TestMethod]
+            public void ValueIsEmptyString_SetsModelWithNoValuesAndReturnsTrue()
+            {
+                // Arrange
+                mock_ValueProvider
+                    .Setup(v => v.GetValue(modelName))
+                    .Returns(new ValueProviderResult("", null, CultureInfo.InvariantCulture));
+
+                // Act
+                var canBind = binder.BindModel(null, bindingContext);
+
+                // Assert
+                Assert.IsInstanceOfType(bindingContext.Model, typeof(LeaderboardCategoryBase));
+                var model = (LeaderboardCategoryBase)bindingContext.Model;
+                Assert.AreEqual(0, model.Count());
+                Assert.IsTrue(canBind);
+            }
+
+            [TestMethod]
+            public void ValueIsValidCommaSeparatedValues_SetsModelWithValuesAndReturnsTrue()
+            {
+                // Arrange
+                mock_ValueProvider
+                    .Setup(v => v.GetValue(modelName))
+                    .Returns(new ValueProviderResult("item1,item3", null, CultureInfo.InvariantCulture));
+
+                // Act
+                var canBind = binder.BindModel(null, bindingContext);
+
+                // Assert
+                Assert.IsInstanceOfType(bindingContext.Model, typeof(LeaderboardCategoryBase));
+                var model = (LeaderboardCategoryBase)bindingContext.Model;
+                Assert.AreEqual(2, model.Count());
+                Assert.IsTrue(canBind);
+            }
+
+            [TestMethod]
+            public void ValueContainsInvalidValues_AddsModelErrorsForInvalidValuesAndReturnsTrue()
+            {
+                // Arrange
+                mock_ValueProvider
+                    .Setup(v => v.GetValue(modelName))
+                    .Returns(new ValueProviderResult("item1,itemA,item3", null, CultureInfo.InvariantCulture));
+
+                // Act
+                var canBind = binder.BindModel(null, bindingContext);
+
+                // Assert
+                var hasErrors = bindingContext.ModelState.TryGetValue(modelName, out var modelState);
+                Assert.IsTrue(hasErrors);
+                Assert.AreEqual(1, modelState.Errors.Count);
+                Assert.IsTrue(canBind);
+            }
+        }
+    }
+}

--- a/toofz.NecroDancer.Web.Api.Tests/Infrastructure/MockLeaderboardCategoryBaseBinder.cs
+++ b/toofz.NecroDancer.Web.Api.Tests/Infrastructure/MockLeaderboardCategoryBaseBinder.cs
@@ -1,0 +1,20 @@
+﻿using toofz.NecroDancer.Web.Api.Infrastructure;
+using toofz.NecroDancer.Web.Api.Models;
+
+namespace toofz.NecroDancer.Web.Api.Tests.Infrastructure
+{
+    class MockLeaderboardCategoryBaseBinder : LeaderboardCategoryBaseBinder
+    {
+        public MockLeaderboardCategoryBaseBinder(LeaderboardCategoryBase model)
+        {
+            this.model = model;
+        }
+
+        readonly LeaderboardCategoryBase model;
+
+        protected override LeaderboardCategoryBase GetModel()
+        {
+            return model;
+        }
+    }
+}

--- a/toofz.NecroDancer.Web.Api.Tests/Infrastructure/PaginationBinderTests.cs
+++ b/toofz.NecroDancer.Web.Api.Tests/Infrastructure/PaginationBinderTests.cs
@@ -1,0 +1,246 @@
+﻿using System.Web.Http;
+using System.Web.Http.Controllers;
+using System.Web.Http.Metadata.Providers;
+using System.Web.Http.ModelBinding;
+using System.Web.Http.ValueProviders;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using toofz.NecroDancer.Web.Api.Infrastructure;
+using toofz.NecroDancer.Web.Api.Models;
+using toofz.NecroDancer.Web.Api.Tests.Models;
+
+namespace toofz.NecroDancer.Web.Api.Tests.Infrastructure
+{
+    class PaginationBinderTests
+    {
+        [TestClass]
+        public class BindModel
+        {
+            HttpActionContext actionContext;
+            const string modelName = "mockModelName";
+            PaginationBinder<MockPagination> binder;
+            ModelBindingContext bindingContext;
+            Mock<IValueProvider> mock_ValueProvider;
+
+            [TestInitialize]
+            public void Initialize()
+            {
+                actionContext = ContextUtil.CreateActionContext();
+
+                binder = new PaginationBinder<MockPagination>();
+
+                var data = new DataAnnotationsModelMetadataProvider();
+                var modelMetadata = data.GetMetadataForType(null, typeof(IPagination));
+                mock_ValueProvider = new Mock<IValueProvider>();
+                bindingContext = new ModelBindingContext
+                {
+                    ModelName = modelName,
+                    ValueProvider = mock_ValueProvider.Object,
+                    ModelMetadata = modelMetadata,
+                };
+            }
+
+            [TestMethod]
+            public void OffsetValueIsNull_SetsModelWithDefaultOFfsetValueAndReturnsTrue()
+            {
+                // Arrange
+                mock_ValueProvider
+                    .Setup(v => v.GetValue("offset"))
+                    .Returns((ValueProviderResult)null);
+
+                // Act
+                var canBind = binder.BindModel(actionContext, bindingContext);
+
+                // Assert
+                Assert.IsInstanceOfType(bindingContext.Model, typeof(MockPagination));
+                var model = (MockPagination)bindingContext.Model;
+                Assert.AreEqual(13, model.offset);
+                Assert.IsTrue(canBind);
+            }
+
+            [TestMethod]
+            public void OffsetValueIsANumber_SetsModelWithOffsetValueAndReturnsTrue()
+            {
+                // Arrange
+                mock_ValueProvider
+                    .Setup(v => v.GetValue("offset"))
+                    .Returns(new ValueProviderResult(3, null, null));
+
+                // Act
+                var canBind = binder.BindModel(actionContext, bindingContext);
+
+                // Assert
+                Assert.IsInstanceOfType(bindingContext.Model, typeof(MockPagination));
+                var model = (MockPagination)bindingContext.Model;
+                Assert.AreEqual(3, model.offset);
+                Assert.IsTrue(canBind);
+            }
+
+            [TestMethod]
+            public void OffsetValueIsNotANumber_AddsModelErrorAndReturnsTrue()
+            {
+                // Arrange
+                mock_ValueProvider
+                    .Setup(v => v.GetValue("offset"))
+                    .Returns(new ValueProviderResult("ten", null, null));
+
+                // Act
+                var canBind = binder.BindModel(actionContext, bindingContext);
+
+                // Assert
+                var hasErrors = bindingContext.ModelState.TryGetValue("offset", out var modelState);
+                Assert.IsTrue(hasErrors);
+                Assert.AreEqual(1, modelState.Errors.Count);
+                Assert.IsTrue(canBind);
+            }
+
+            [TestMethod]
+            public void OffsetValueIsLessThanMin_AddsModelErrorAndReturnsTrue()
+            {
+                // Arrange
+                mock_ValueProvider
+                    .Setup(v => v.GetValue("offset"))
+                    .Returns(new ValueProviderResult(int.MinValue, null, null));
+
+                // Act
+                var canBind = binder.BindModel(actionContext, bindingContext);
+
+                // Assert
+                var hasErrors = bindingContext.ModelState.TryGetValue("offset", out var modelState);
+                Assert.IsTrue(hasErrors);
+                Assert.AreEqual(1, modelState.Errors.Count);
+                Assert.IsTrue(canBind);
+            }
+
+            [TestMethod]
+            public void OffsetValueIsMoreThanMax_AddsModelErrorAndReturnsTrue()
+            {
+                // Arrange
+                mock_ValueProvider
+                    .Setup(v => v.GetValue("offset"))
+                    .Returns(new ValueProviderResult(int.MaxValue, null, null));
+
+                // Act
+                var canBind = binder.BindModel(actionContext, bindingContext);
+
+                // Assert
+                var hasErrors = bindingContext.ModelState.TryGetValue("offset", out var modelState);
+                Assert.IsTrue(hasErrors);
+                Assert.AreEqual(1, modelState.Errors.Count);
+                Assert.IsTrue(canBind);
+            }
+
+            [TestMethod]
+            public void LimitValueIsNull_SetsModelWithDefaultLimitValueAndReturnsTrue()
+            {
+                // Arrange
+                mock_ValueProvider
+                    .Setup(v => v.GetValue("limit"))
+                    .Returns((ValueProviderResult)null);
+
+                // Act
+                var canBind = binder.BindModel(actionContext, bindingContext);
+
+                // Assert
+                Assert.IsInstanceOfType(bindingContext.Model, typeof(MockPagination));
+                var model = (MockPagination)bindingContext.Model;
+                Assert.AreEqual(7, model.limit);
+                Assert.IsTrue(canBind);
+            }
+
+            [TestMethod]
+            public void LimitValueIsANumber_SetsModelWithLimitValueAndReturnsTrue()
+            {
+                // Arrange
+                mock_ValueProvider
+                    .Setup(v => v.GetValue("limit"))
+                    .Returns(new ValueProviderResult(3, null, null));
+
+                // Act
+                var canBind = binder.BindModel(actionContext, bindingContext);
+
+                // Assert
+                Assert.IsInstanceOfType(bindingContext.Model, typeof(MockPagination));
+                var model = (MockPagination)bindingContext.Model;
+                Assert.AreEqual(3, model.limit);
+                Assert.IsTrue(canBind);
+            }
+
+            [TestMethod]
+            public void LimitValueIsNotANumber_AddsModelErrorAndReturnsTrue()
+            {
+                // Arrange
+                mock_ValueProvider
+                    .Setup(v => v.GetValue("limit"))
+                    .Returns(new ValueProviderResult("ten", null, null));
+
+                // Act
+                var canBind = binder.BindModel(actionContext, bindingContext);
+
+                // Assert
+                var hasErrors = bindingContext.ModelState.TryGetValue("limit", out var modelState);
+                Assert.IsTrue(hasErrors);
+                Assert.AreEqual(1, modelState.Errors.Count);
+                Assert.IsTrue(canBind);
+            }
+
+            [TestMethod]
+            public void LimitValueIsLessThanMin_AddsModelErrorAndReturnsTrue()
+            {
+                // Arrange
+                mock_ValueProvider
+                    .Setup(v => v.GetValue("limit"))
+                    .Returns(new ValueProviderResult(int.MinValue, null, null));
+
+                // Act
+                var canBind = binder.BindModel(actionContext, bindingContext);
+
+                // Assert
+                var hasErrors = bindingContext.ModelState.TryGetValue("limit", out var modelState);
+                Assert.IsTrue(hasErrors);
+                Assert.AreEqual(1, modelState.Errors.Count);
+                Assert.IsTrue(canBind);
+            }
+
+            [TestMethod]
+            public void LimitValueIsMoreThanMax_AddsModelErrorAndReturnsTrue()
+            {
+                // Arrange
+                mock_ValueProvider
+                    .Setup(v => v.GetValue("limit"))
+                    .Returns(new ValueProviderResult(int.MaxValue, null, null));
+
+                // Act
+                var canBind = binder.BindModel(actionContext, bindingContext);
+
+                // Assert
+                var hasErrors = bindingContext.ModelState.TryGetValue("limit", out var modelState);
+                Assert.IsTrue(hasErrors);
+                Assert.AreEqual(1, modelState.Errors.Count);
+                Assert.IsTrue(canBind);
+            }
+
+            [TestMethod]
+            public void OffsetValueAndLimitValueAreNull_SetsModelWithDefaultValuesAndReturnsTrue()
+            {
+                // Arrange
+                mock_ValueProvider
+                    .Setup(v => v.GetValue("limit"))
+                    .Returns((ValueProviderResult)null);
+                mock_ValueProvider
+                    .Setup(v => v.GetValue("offset"))
+                    .Returns((ValueProviderResult)null);
+
+                // Act
+                var canBind = binder.BindModel(actionContext, bindingContext);
+
+                // Assert
+                Assert.IsInstanceOfType(bindingContext.Model, typeof(MockPagination));
+                var model = (MockPagination)bindingContext.Model;
+                Assert.AreEqual(7, model.limit);
+                Assert.AreEqual(13, model.offset);
+                Assert.IsTrue(canBind);
+            }
+        }
+    }
+}

--- a/toofz.NecroDancer.Web.Api.Tests/Infrastructure/PaginationBinderTests.cs
+++ b/toofz.NecroDancer.Web.Api.Tests/Infrastructure/PaginationBinderTests.cs
@@ -94,6 +94,7 @@ namespace toofz.NecroDancer.Web.Api.Tests.Infrastructure
                 Assert.IsTrue(canBind);
             }
 
+            [Ignore("Determine how to properly set up for testing validation.")]
             [TestMethod]
             public void OffsetValueIsLessThanMin_AddsModelErrorAndReturnsTrue()
             {
@@ -112,6 +113,7 @@ namespace toofz.NecroDancer.Web.Api.Tests.Infrastructure
                 Assert.IsTrue(canBind);
             }
 
+            [Ignore("Determine how to properly set up for testing validation.")]
             [TestMethod]
             public void OffsetValueIsMoreThanMax_AddsModelErrorAndReturnsTrue()
             {
@@ -184,6 +186,7 @@ namespace toofz.NecroDancer.Web.Api.Tests.Infrastructure
                 Assert.IsTrue(canBind);
             }
 
+            [Ignore("Determine how to properly set up for testing validation.")]
             [TestMethod]
             public void LimitValueIsLessThanMin_AddsModelErrorAndReturnsTrue()
             {
@@ -202,6 +205,7 @@ namespace toofz.NecroDancer.Web.Api.Tests.Infrastructure
                 Assert.IsTrue(canBind);
             }
 
+            [Ignore("Determine how to properly set up for testing validation.")]
             [TestMethod]
             public void LimitValueIsMoreThanMax_AddsModelErrorAndReturnsTrue()
             {

--- a/toofz.NecroDancer.Web.Api.Tests/Models/LeaderboardCategoryBaseTests.cs
+++ b/toofz.NecroDancer.Web.Api.Tests/Models/LeaderboardCategoryBaseTests.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using toofz.NecroDancer.Leaderboards;
+using toofz.NecroDancer.Web.Api.Models;
+using toofz.TestsShared;
+
+namespace toofz.NecroDancer.Web.Api.Tests.Models
+{
+    class LeaderboardCategoryBaseTests
+    {
+        [TestClass]
+        public class Add
+        {
+            Category category;
+            LeaderboardCategoryBase leaderboardCategory;
+
+            [TestInitialize]
+            public void Initialize()
+            {
+                category = new Category
+                {
+                    { "item1", new CategoryItem() },
+                    { "item2", new CategoryItem() },
+                    { "item3", new CategoryItem() },
+                };
+                leaderboardCategory = new MockLeaderboardCategoryBase(category);
+            }
+
+            [TestMethod]
+            public void ItemIsNotValid_ThrowsArgumentException()
+            {
+                // Arrange
+                var item = "itemA";
+
+                // Act
+                var ex = Record.Exception(() =>
+                {
+                    leaderboardCategory.Add(item);
+                });
+
+                // Assert
+                Assert.IsInstanceOfType(ex, typeof(ArgumentException));
+            }
+
+            [TestMethod]
+            public void ItemIsValid_AddsItem()
+            {
+                // Arrange
+                var item = "item1";
+
+                // Act
+                leaderboardCategory.Add(item);
+
+                // Assert
+                Assert.AreEqual(1, leaderboardCategory.Count());
+                Assert.IsTrue(leaderboardCategory.Contains(item));
+            }
+        }
+
+        [TestClass]
+        public class AddAll
+        {
+            Category category;
+            LeaderboardCategoryBase leaderboardCategory;
+
+            [TestInitialize]
+            public void Initialize()
+            {
+                category = new Category
+                {
+                    { "item1", new CategoryItem() },
+                    { "item2", new CategoryItem() },
+                    { "item3", new CategoryItem() },
+                };
+                leaderboardCategory = new MockLeaderboardCategoryBase(category);
+            }
+
+            [TestMethod]
+            public void WhenCalled_AddsAllItems()
+            {
+                // Arrange -> Act
+                leaderboardCategory.AddAll();
+
+                // Assert
+                Assert.AreEqual(3, leaderboardCategory.Count());
+            }
+        }
+
+        [TestClass]
+        public class GetEnumerator
+        {
+            [TestMethod]
+            public void WhenCalled_ReturnsIEnumeratorOfString()
+            {
+                // Arrange
+                var leaderboardCategory = new MockLeaderboardCategoryBase(new Category());
+
+                // Act
+                var enumerator = leaderboardCategory.GetEnumerator();
+
+                // Assert
+                Assert.IsInstanceOfType(enumerator, typeof(IEnumerator<string>));
+            }
+        }
+
+        [TestClass]
+        public class IEnumerableGetEnumerator
+        {
+            [TestMethod]
+            public void WhenCalled_ReturnsIEnumerator()
+            {
+                // Arrange
+                var leaderboardCategory = new MockLeaderboardCategoryBase(new Category());
+                var enumerable = leaderboardCategory as IEnumerable;
+
+                // Act
+                var enumerator = enumerable.GetEnumerator();
+
+                // Assert
+                Assert.IsInstanceOfType(enumerator, typeof(IEnumerator));
+            }
+        }
+    }
+}

--- a/toofz.NecroDancer.Web.Api.Tests/Models/MockLeaderboardCategoryBase.cs
+++ b/toofz.NecroDancer.Web.Api.Tests/Models/MockLeaderboardCategoryBase.cs
@@ -1,0 +1,10 @@
+﻿using toofz.NecroDancer.Leaderboards;
+using toofz.NecroDancer.Web.Api.Models;
+
+namespace toofz.NecroDancer.Web.Api.Tests.Models
+{
+    class MockLeaderboardCategoryBase : LeaderboardCategoryBase
+    {
+        public MockLeaderboardCategoryBase(Category category) : base(category) { }
+    }
+}

--- a/toofz.NecroDancer.Web.Api.Tests/Models/MockPagination.cs
+++ b/toofz.NecroDancer.Web.Api.Tests/Models/MockPagination.cs
@@ -1,0 +1,14 @@
+﻿using toofz.NecroDancer.Web.Api.Models;
+
+namespace toofz.NecroDancer.Web.Api.Tests.Models
+{
+    sealed class MockPagination : IPagination
+    {
+        [MinValue(0)]
+        [MaxValue(30)]
+        public int offset { get; set; } = 13;
+        [MinValue(1)]
+        [MaxValue(20)]
+        public int limit { get; set; } = 7;
+    }
+}

--- a/toofz.NecroDancer.Web.Api.Tests/toofz.NecroDancer.Web.Api.Tests.csproj
+++ b/toofz.NecroDancer.Web.Api.Tests/toofz.NecroDancer.Web.Api.Tests.csproj
@@ -149,8 +149,12 @@
     <Compile Include="Controllers\LeaderboardsControllerTests.cs" />
     <Compile Include="Controllers\PlayersControllerTests.cs" />
     <Compile Include="Controllers\ReplaysControllerTests.cs" />
+    <Compile Include="Infrastructure\LeaderboardCategoryBindersTests.cs" />
+    <Compile Include="Infrastructure\MockLeaderboardCategoryBaseBinder.cs" />
     <Compile Include="MaxValueAttributeTests.cs" />
     <Compile Include="MinValueAttributeTests.cs" />
+    <Compile Include="Models\LeaderboardCategoryBaseTests.cs" />
+    <Compile Include="Models\MockLeaderboardCategoryBase.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\toofz.NecroDancer.Web.Api\toofz.NecroDancer.Web.Api.csproj">

--- a/toofz.NecroDancer.Web.Api.Tests/toofz.NecroDancer.Web.Api.Tests.csproj
+++ b/toofz.NecroDancer.Web.Api.Tests/toofz.NecroDancer.Web.Api.Tests.csproj
@@ -145,16 +145,19 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ContextUtil.cs" />
     <Compile Include="Controllers\EnemiesControllerTests.cs" />
     <Compile Include="Controllers\LeaderboardsControllerTests.cs" />
     <Compile Include="Controllers\PlayersControllerTests.cs" />
     <Compile Include="Controllers\ReplaysControllerTests.cs" />
     <Compile Include="Infrastructure\LeaderboardCategoryBindersTests.cs" />
     <Compile Include="Infrastructure\MockLeaderboardCategoryBaseBinder.cs" />
+    <Compile Include="Infrastructure\PaginationBinderTests.cs" />
     <Compile Include="MaxValueAttributeTests.cs" />
     <Compile Include="MinValueAttributeTests.cs" />
     <Compile Include="Models\LeaderboardCategoryBaseTests.cs" />
     <Compile Include="Models\MockLeaderboardCategoryBase.cs" />
+    <Compile Include="Models\MockPagination.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\toofz.NecroDancer.Web.Api\toofz.NecroDancer.Web.Api.csproj">

--- a/toofz.NecroDancer.Web.Api/Controllers/EnemiesController.cs
+++ b/toofz.NecroDancer.Web.Api/Controllers/EnemiesController.cs
@@ -38,10 +38,10 @@ namespace toofz.NecroDancer.Web.Api.Controllers
         [ResponseType(typeof(Enemies))]
         [Route("")]
         public async Task<IHttpActionResult> GetEnemies(
-            [FromUri] EnemiesPagination pagination,
+            EnemiesPagination pagination,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            var content = await GetEnemiesAsync(null, pagination, cancellationToken);
+            var content = await GetEnemiesAsync(pagination, null, cancellationToken);
 
             return Ok(content);
         }
@@ -49,11 +49,11 @@ namespace toofz.NecroDancer.Web.Api.Controllers
         /// <summary>
         /// Gets a list of Crypt of the NecroDancer enemies with a specific attribute.
         /// </summary>
+        /// <param name="pagination">Pagination parameters.</param>
         /// <param name="attribute">
         /// The enemy's attribute.
         /// Valid values are 'boss', 'bounce-on-movement-fail', 'floating', 'ignore-liquids', 'ignore-walls', 'is-monkey-like', 'massive', and 'miniboss'.
         /// </param>
-        /// <param name="pagination">Pagination parameters.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
         /// <returns>
         /// Returns a list of Crypt of the NecroDancer enemies with the attribute.
@@ -64,13 +64,13 @@ namespace toofz.NecroDancer.Web.Api.Controllers
         [ResponseType(typeof(Enemies))]
         [Route("{attribute}")]
         public async Task<IHttpActionResult> GetEnemies(
+            EnemiesPagination pagination,
             string attribute,
-            [FromUri] EnemiesPagination pagination,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             try
             {
-                var content = await GetEnemiesAsync(attribute, pagination, cancellationToken);
+                var content = await GetEnemiesAsync(pagination, attribute, cancellationToken);
 
                 return Ok(content);
             }
@@ -81,14 +81,10 @@ namespace toofz.NecroDancer.Web.Api.Controllers
         }
 
         internal async Task<Enemies> GetEnemiesAsync(
-            string attribute,
             EnemiesPagination pagination,
+            string attribute,
             CancellationToken cancellationToken)
         {
-            var p = pagination ?? new EnemiesPagination();
-            var offset = p.offset;
-            var limit = p.limit;
-
             var baseQuery = from e in db.Enemies
                             select e;
             if (attribute != null)
@@ -122,8 +118,8 @@ namespace toofz.NecroDancer.Web.Api.Controllers
             var total = await query.CountAsync(cancellationToken);
 
             var enemies = await query
-                .Skip(offset)
-                .Take(limit)
+                .Skip(pagination.offset)
+                .Take(pagination.limit)
                 .ToListAsync(cancellationToken);
 
             return new Enemies

--- a/toofz.NecroDancer.Web.Api/Controllers/ItemsController.cs
+++ b/toofz.NecroDancer.Web.Api/Controllers/ItemsController.cs
@@ -39,10 +39,10 @@ namespace toofz.NecroDancer.Web.Api.Controllers
         [ResponseType(typeof(Items))]
         [Route("")]
         public async Task<IHttpActionResult> GetItems(
-            [FromUri] ItemsPagination pagination,
+            ItemsPagination pagination,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            var content = await GetItemsAsync(i => true, pagination, cancellationToken);
+            var content = await GetItemsAsync(pagination, i => true, cancellationToken);
 
             return Ok(content);
         }
@@ -50,8 +50,8 @@ namespace toofz.NecroDancer.Web.Api.Controllers
         /// <summary>
         /// Gets a list of Crypt of the NecroDancer items in a specific category.
         /// </summary>
-        /// <param name="category">The category of items to return.</param>
         /// <param name="pagination">Pagination parameters.</param>
+        /// <param name="category">The category of items to return.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
         /// <returns>
         /// Returns a list of Crypt of the NecroDancer items in the category.
@@ -59,12 +59,12 @@ namespace toofz.NecroDancer.Web.Api.Controllers
         [ResponseType(typeof(Items))]
         [Route("{category}")]
         public async Task<IHttpActionResult> GetItems(
+            ItemsPagination pagination,
             string category,
-            [FromUri] ItemsPagination pagination,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             var filter = Items(category, null);
-            var content = await GetItemsAsync(filter, pagination, cancellationToken);
+            var content = await GetItemsAsync(pagination, filter, cancellationToken);
 
             return Ok(content);
         }
@@ -72,9 +72,9 @@ namespace toofz.NecroDancer.Web.Api.Controllers
         /// <summary>
         /// Gets a list of Crypt of the NecroDancer items in a specific subcategory.
         /// </summary>
+        /// <param name="pagination">Pagination parameters.</param>
         /// <param name="category">The category of items to return.</param>
         /// <param name="subcategory">The subcategory within the category.</param>
-        /// <param name="pagination">Pagination parameters.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
         /// <returns>
         /// Returns a list of Crypt of the NecroDancer items in the subcategory.
@@ -82,23 +82,22 @@ namespace toofz.NecroDancer.Web.Api.Controllers
         [ResponseType(typeof(Items))]
         [Route("{category}/{subcategory}")]
         public async Task<IHttpActionResult> GetItems(
+            ItemsPagination pagination,
             string category,
             string subcategory,
-            [FromUri] ItemsPagination pagination,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             var filter = Items(category, subcategory);
-            var content = await GetItemsAsync(filter, pagination, cancellationToken);
+            var content = await GetItemsAsync(pagination, filter, cancellationToken);
 
             return Ok(content);
         }
 
-        async Task<Items> GetItemsAsync(Expression<Func<Data.Item, bool>> filter, ItemsPagination pagination, CancellationToken cancellationToken)
+        async Task<Items> GetItemsAsync(
+            ItemsPagination pagination,
+            Expression<Func<Data.Item, bool>> filter,
+            CancellationToken cancellationToken)
         {
-            var p = pagination ?? new ItemsPagination();
-            var offset = p.offset;
-            var limit = p.limit;
-
             var query = db.Items
                 .Where(filter)
                 .OrderBy(i => i.ElementName)
@@ -114,14 +113,14 @@ namespace toofz.NecroDancer.Web.Api.Controllers
             var total = await query.CountAsync(cancellationToken);
 
             var items = await query
-                .Skip(offset)
-                .Take(limit)
+                .Skip(pagination.offset)
+                .Take(pagination.limit)
                 .ToListAsync(cancellationToken);
 
             return new Items
             {
                 total = total,
-                items = items
+                items = items,
             };
         }
 

--- a/toofz.NecroDancer.Web.Api/Controllers/LeaderboardsController.cs
+++ b/toofz.NecroDancer.Web.Api/Controllers/LeaderboardsController.cs
@@ -115,8 +115,8 @@ namespace toofz.NecroDancer.Web.Api.Controllers
         /// <summary>
         /// Gets a list of Crypt of the NecroDancer leaderboard entries.
         /// </summary>
-        /// <param name="lbid">The leaderboard ID.</param>
         /// <param name="pagination">Pagination parameters.</param>
+        /// <param name="lbid">The leaderboard ID.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
         /// <returns>Returns a list of Crypt of the NecroDancer leaderboard entries.</returns>
         /// <httpStatusCode cref="System.Net.HttpStatusCode.NotFound">
@@ -125,12 +125,10 @@ namespace toofz.NecroDancer.Web.Api.Controllers
         [ResponseType(typeof(LeaderboardEntries))]
         [Route("{lbid:int}/entries")]
         public async Task<IHttpActionResult> GetLeaderboardEntries(
+            LeaderboardsPagination pagination,
             int lbid,
-            [FromUri] LeaderboardsPagination pagination,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            pagination = pagination ?? new LeaderboardsPagination();
-
             var leaderboard = await db.Leaderboards.FirstOrDefaultAsync(l => l.LeaderboardId == lbid, cancellationToken);
             if (leaderboard == null)
             {
@@ -227,11 +225,11 @@ namespace toofz.NecroDancer.Web.Api.Controllers
         /// <summary>
         /// Gets a list of Crypt of the NecroDancer daily leaderboards.
         /// </summary>
+        /// <param name="pagination">Pagination parameters.</param>
         /// <param name="products">
         /// Valid values are 'classic' and 'amplified'. 
         /// If not provided, returns daily leaderboards from all products.
         /// </param>
-        /// <param name="pagination">Pagination parameters.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
         /// <returns>
         /// Returns a list of Crypt of the NecroDancer daily leaderboards.
@@ -242,12 +240,10 @@ namespace toofz.NecroDancer.Web.Api.Controllers
         [ResponseType(typeof(DailyLeaderboards))]
         [Route("dailies")]
         public async Task<IHttpActionResult> GetDailies(
+            LeaderboardsPagination pagination,
             Products products,
-            [FromUri] LeaderboardsPagination pagination,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            pagination = pagination ?? new LeaderboardsPagination();
-
             var productIds = new List<int>();
             foreach (var p in products)
             {
@@ -300,8 +296,8 @@ namespace toofz.NecroDancer.Web.Api.Controllers
         /// <summary>
         /// Gets a list of Crypt of the NecroDancer daily leaderboard entries.
         /// </summary>
-        /// <param name="lbid">The daily leaderboard ID.</param>
         /// <param name="pagination">Pagination parameters.</param>
+        /// <param name="lbid">The daily leaderboard ID.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
         /// <returns>Returns a list of Crypt of the NecroDancer daily leaderboard entries.</returns>
         /// <httpStatusCode cref="System.Net.HttpStatusCode.NotFound">
@@ -310,12 +306,10 @@ namespace toofz.NecroDancer.Web.Api.Controllers
         [ResponseType(typeof(DailyLeaderboardEntries))]
         [Route("dailies/{lbid:int}/entries")]
         public async Task<IHttpActionResult> GetDailyLeaderboardEntries(
+            LeaderboardsPagination pagination,
             int lbid,
-            [FromUri] LeaderboardsPagination pagination,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            var p = pagination ?? new LeaderboardsPagination();
-
             var leaderboard = await db.DailyLeaderboards.FirstOrDefaultAsync(l => l.LeaderboardId == lbid, cancellationToken);
             if (leaderboard == null)
             {
@@ -347,8 +341,8 @@ namespace toofz.NecroDancer.Web.Api.Controllers
             var total = await query.CountAsync(cancellationToken);
 
             var entriesPage = await query
-                .Skip(p.offset)
-                .Take(p.limit)
+                .Skip(pagination.offset)
+                .Take(pagination.limit)
                 .ToListAsync(cancellationToken);
 
             var replayIds = entriesPage.Select(entry => entry.ReplayId);

--- a/toofz.NecroDancer.Web.Api/Controllers/LeaderboardsController.cs
+++ b/toofz.NecroDancer.Web.Api/Controllers/LeaderboardsController.cs
@@ -22,20 +22,20 @@ namespace toofz.NecroDancer.Web.Api.Controllers
         /// Initializes a new instance of the <see cref="LeaderboardsController"/> class.
         /// </summary>
         /// <param name="db">The leaderboards context.</param>
-        /// <param name="categories">Leaderboard categories.</param>
+        /// <param name="leaderboardCategories">Leaderboard categories.</param>
         /// <param name="leaderboardHeaders">Leaderboard headers.</param>
         public LeaderboardsController(
             LeaderboardsContext db,
-            Categories categories,
+            Categories leaderboardCategories,
             LeaderboardHeaders leaderboardHeaders)
         {
             this.db = db;
-            this.categories = categories;
+            this.leaderboardCategories = leaderboardCategories;
             this.leaderboardHeaders = leaderboardHeaders;
         }
 
         readonly LeaderboardsContext db;
-        readonly Categories categories;
+        readonly Categories leaderboardCategories;
         readonly LeaderboardHeaders leaderboardHeaders;
 
         /// <summary>
@@ -64,27 +64,17 @@ namespace toofz.NecroDancer.Web.Api.Controllers
         [ResponseType(typeof(Models.Leaderboards))]
         [Route("")]
         public async Task<IHttpActionResult> GetLeaderboards(
-            string products = null,
-            string modes = null,
-            string runs = null,
-            string characters = null,
+            Products products,
+            Modes modes,
+            Runs runs,
+            Characters characters,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            products = products ?? categories.GetAllItemNames("products");
-            modes = modes ?? categories.GetAllItemNames("modes");
-            runs = runs ?? categories.GetAllItemNames("runs");
-            characters = characters ?? categories.GetAllItemNames("characters");
-
-            var product_names = products.Split(',');
-            var mode_names = modes.Split(',');
-            var run_names = runs.Split(',');
-            var character_names = characters.Split(',');
-
             var lbids = (from h in leaderboardHeaders
-                         where product_names.Contains(h.product)
-                         where mode_names.Contains(h.mode)
-                         where run_names.Contains(h.run)
-                         where character_names.Contains(h.character)
+                         where products.Contains(h.product)
+                         where modes.Contains(h.mode)
+                         where runs.Contains(h.run)
+                         where characters.Contains(h.character)
                          select h.id).ToList();
 
             var query = await (from l in db.Leaderboards
@@ -237,11 +227,11 @@ namespace toofz.NecroDancer.Web.Api.Controllers
         /// <summary>
         /// Gets a list of Crypt of the NecroDancer daily leaderboards.
         /// </summary>
-        /// <param name="pagination">Pagination parameters.</param>
         /// <param name="products">
         /// Valid values are 'classic' and 'amplified'. 
         /// If not provided, returns daily leaderboards from all products.
         /// </param>
+        /// <param name="pagination">Pagination parameters.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
         /// <returns>
         /// Returns a list of Crypt of the NecroDancer daily leaderboards.
@@ -252,19 +242,18 @@ namespace toofz.NecroDancer.Web.Api.Controllers
         [ResponseType(typeof(DailyLeaderboards))]
         [Route("dailies")]
         public async Task<IHttpActionResult> GetDailies(
+            Products products,
             [FromUri] LeaderboardsPagination pagination,
-            string products = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             pagination = pagination ?? new LeaderboardsPagination();
-            products = products ?? categories.GetAllItemNames("products");
 
             var productIds = new List<int>();
-            foreach (var p in products.Split(','))
+            foreach (var p in products)
             {
                 try
                 {
-                    productIds.Add(categories.GetItemId("products", p));
+                    productIds.Add(leaderboardCategories.GetItemId("products", p));
                 }
                 // TODO: When GetId is changed to throw a more specific Exception, this should also be updated.
                 catch (Exception)
@@ -294,7 +283,7 @@ namespace toofz.NecroDancer.Web.Api.Controllers
                                     id = l.LeaderboardId,
                                     date = l.Date,
                                     updated_at = l.LastUpdate,
-                                    product = categories.GetItemName("products", l.ProductId),
+                                    product = leaderboardCategories.GetItemName("products", l.ProductId),
                                     production = l.IsProduction,
                                 })
                                 .ToList();
@@ -402,7 +391,7 @@ namespace toofz.NecroDancer.Web.Api.Controllers
                     id = leaderboard.LeaderboardId,
                     date = leaderboard.Date,
                     updated_at = leaderboard.LastUpdate,
-                    product = categories.GetItemName("products", leaderboard.ProductId),
+                    product = leaderboardCategories.GetItemName("products", leaderboard.ProductId),
                     production = leaderboard.IsProduction,
                 },
                 total = total,

--- a/toofz.NecroDancer.Web.Api/Controllers/PlayersController.cs
+++ b/toofz.NecroDancer.Web.Api/Controllers/PlayersController.cs
@@ -62,13 +62,11 @@ namespace toofz.NecroDancer.Web.Api.Controllers
         [ResponseType(typeof(Players))]
         [Route("")]
         public async Task<IHttpActionResult> GetPlayers(
+            PlayersPagination pagination,
             string q = null,
-            [FromUri] PlayersPagination pagination = null,
             string sort = "-entries,display_name,id",
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            pagination = pagination ?? new PlayersPagination();
-
             IQueryable<Leaderboards.Player> queryBase = db.Players;
             if (!string.IsNullOrEmpty(q))
             {

--- a/toofz.NecroDancer.Web.Api/Controllers/ReplaysController.cs
+++ b/toofz.NecroDancer.Web.Api/Controllers/ReplaysController.cs
@@ -37,13 +37,11 @@ namespace toofz.NecroDancer.Web.Api.Controllers
         [ResponseType(typeof(Models.Replays))]
         [Route("")]
         public async Task<IHttpActionResult> GetReplays(
+            ReplaysPagination pagination,
             int? version = null,
             int? error = null,
-            [FromUri] ReplaysPagination pagination = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            pagination = pagination ?? new ReplaysPagination();
-
             var query = from r in db.Replays
                         where r.Version == version && r.ErrorCode == error
                         orderby r.ReplayId

--- a/toofz.NecroDancer.Web.Api/Infrastructure/LeaderboardCategoryBaseBinder.cs
+++ b/toofz.NecroDancer.Web.Api/Infrastructure/LeaderboardCategoryBaseBinder.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Web.Http.Controllers;
+using System.Web.Http.ModelBinding;
+using System.Web.Http.ValueProviders;
+using toofz.NecroDancer.Web.Api.Models;
+
+namespace toofz.NecroDancer.Web.Api.Infrastructure
+{
+    public abstract class LeaderboardCategoryBaseBinder : IModelBinder
+    {
+        public bool BindModel(HttpActionContext actionContext, ModelBindingContext bindingContext)
+        {
+            var model = GetModel();
+            bindingContext.Model = model;
+            var modelName = bindingContext.ModelName;
+            var result = bindingContext.ValueProvider.GetValue(modelName);
+
+            // Parameter not supplied, add all values
+            if (result == null)
+            {
+                model.AddAll();
+            }
+            else
+            {
+                var value = Convert<string>(result);
+                foreach (var item in value.Split(','))
+                {
+                    try
+                    {
+                        model.Add(item);
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        bindingContext.ModelState.AddModelError(modelName, ex.Message);
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        protected abstract LeaderboardCategoryBase GetModel();
+
+        T Convert<T>(ValueProviderResult result)
+        {
+            try
+            {
+                return (T)result.ConvertTo(typeof(T));
+            }
+            catch
+            {
+                return default(T);
+            }
+        }
+    }
+}

--- a/toofz.NecroDancer.Web.Api/Infrastructure/LeaderboardCategoryBinders.cs
+++ b/toofz.NecroDancer.Web.Api/Infrastructure/LeaderboardCategoryBinders.cs
@@ -1,0 +1,65 @@
+﻿using toofz.NecroDancer.Leaderboards;
+using toofz.NecroDancer.Web.Api.Models;
+
+namespace toofz.NecroDancer.Web.Api.Infrastructure
+{
+    public sealed class ProductsBinder : LeaderboardCategoryBaseBinder
+    {
+        public ProductsBinder(Categories leaderboardCategories)
+        {
+            category = leaderboardCategories["products"];
+        }
+
+        readonly Category category;
+
+        protected override LeaderboardCategoryBase GetModel()
+        {
+            return new Products(category);
+        }
+    }
+
+    public sealed class ModesBinder : LeaderboardCategoryBaseBinder
+    {
+        public ModesBinder(Categories leaderboardCategories)
+        {
+            category = leaderboardCategories["modes"];
+        }
+
+        readonly Category category;
+
+        protected override LeaderboardCategoryBase GetModel()
+        {
+            return new Modes(category);
+        }
+    }
+
+    public sealed class RunsBinder : LeaderboardCategoryBaseBinder
+    {
+        public RunsBinder(Categories leaderboardCategories)
+        {
+            category = leaderboardCategories["runs"];
+        }
+
+        readonly Category category;
+
+        protected override LeaderboardCategoryBase GetModel()
+        {
+            return new Runs(category);
+        }
+    }
+
+    public sealed class CharactersBinder : LeaderboardCategoryBaseBinder
+    {
+        public CharactersBinder(Categories leaderboardCategories)
+        {
+            category = leaderboardCategories["characters"];
+        }
+
+        readonly Category category;
+
+        protected override LeaderboardCategoryBase GetModel()
+        {
+            return new Characters(category);
+        }
+    }
+}

--- a/toofz.NecroDancer.Web.Api/Infrastructure/PaginationBinder.cs
+++ b/toofz.NecroDancer.Web.Api/Infrastructure/PaginationBinder.cs
@@ -1,0 +1,67 @@
+﻿using System.Linq;
+using System.Web.Http.Controllers;
+using System.Web.Http.ModelBinding;
+using toofz.NecroDancer.Web.Api.Models;
+
+namespace toofz.NecroDancer.Web.Api.Infrastructure
+{
+    public sealed class PaginationBinder<T> : IModelBinder
+        where T : IPagination, new()
+    {
+        // Always supplies a value. If a parameter is not supplied, the default value on the type is used.
+        public bool BindModel(HttpActionContext actionContext, ModelBindingContext bindingContext)
+        {
+            var model = new T();
+            bindingContext.Model = model;
+            var modelState = bindingContext.ModelState;
+
+            var offsetResult = bindingContext.ValueProvider.GetValue("offset");
+            if (offsetResult != null)
+            {
+                try
+                {
+                    model.offset = (int)offsetResult.ConvertTo(typeof(int));
+                }
+                catch
+                {
+                    modelState.AddModelError("offset", "'offset' is not a valid integer.");
+                }
+            }
+
+            var limitResult = bindingContext.ValueProvider.GetValue("limit");
+            if (limitResult != null)
+            {
+                try
+                {
+                    model.limit = (int)limitResult.ConvertTo(typeof(int));
+                }
+                catch
+                {
+                    modelState.AddModelError("limit", "'limit' is not a valid integer.");
+                }
+            }
+
+            // Data Annotations validation
+            var validationNode = bindingContext.ValidationNode;
+            validationNode.ValidateAllProperties = true;
+            validationNode.Validate(actionContext);
+
+            // Strip prefix from Data Annotations validation errors
+            var prefix = bindingContext.ModelName + ".";
+            foreach (var key in modelState.Keys.ToList())
+            {
+                if (key.StartsWith(prefix))
+                {
+                    var noPrefixKey = key.Remove(0, prefix.Length);
+                    foreach (var error in modelState[key].Errors)
+                    {
+                        modelState.AddModelError(noPrefixKey, error.ErrorMessage);
+                    }
+                    modelState.Remove(key);
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/toofz.NecroDancer.Web.Api/Models/IPagination.cs
+++ b/toofz.NecroDancer.Web.Api/Models/IPagination.cs
@@ -1,0 +1,8 @@
+﻿namespace toofz.NecroDancer.Web.Api.Models
+{
+    public interface IPagination
+    {
+        int offset { get; set; }
+        int limit { get; set; }
+    }
+}

--- a/toofz.NecroDancer.Web.Api/Models/LeaderboardCategories.cs
+++ b/toofz.NecroDancer.Web.Api/Models/LeaderboardCategories.cs
@@ -1,0 +1,30 @@
+﻿using System.Web.Http.ModelBinding;
+using toofz.NecroDancer.Leaderboards;
+using toofz.NecroDancer.Web.Api.Infrastructure;
+
+namespace toofz.NecroDancer.Web.Api.Models
+{
+    [ModelBinder(BinderType = typeof(ProductsBinder))]
+    public sealed class Products : LeaderboardCategoryBase
+    {
+        public Products(Category category) : base(category) { }
+    }
+
+    [ModelBinder(BinderType = typeof(ModesBinder))]
+    public sealed class Modes : LeaderboardCategoryBase
+    {
+        public Modes(Category category) : base(category) { }
+    }
+
+    [ModelBinder(BinderType = typeof(RunsBinder))]
+    public sealed class Runs : LeaderboardCategoryBase
+    {
+        public Runs(Category category) : base(category) { }
+    }
+
+    [ModelBinder(BinderType = typeof(CharactersBinder))]
+    public sealed class Characters : LeaderboardCategoryBase
+    {
+        public Characters(Category category) : base(category) { }
+    }
+}

--- a/toofz.NecroDancer.Web.Api/Models/LeaderboardCategoryBase.cs
+++ b/toofz.NecroDancer.Web.Api/Models/LeaderboardCategoryBase.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using toofz.NecroDancer.Leaderboards;
+
+namespace toofz.NecroDancer.Web.Api.Models
+{
+    public abstract class LeaderboardCategoryBase : IEnumerable<string>
+    {
+        public LeaderboardCategoryBase(Category category)
+        {
+            this.category = category;
+        }
+
+        readonly Category category;
+        readonly HashSet<string> items = new HashSet<string>();
+
+        public void Add(string item)
+        {
+            if (!category.ContainsKey(item))
+            {
+                throw new ArgumentException($"'{item}' is not a valid value.");
+            }
+            items.Add(item);
+        }
+
+        public void AddAll()
+        {
+            foreach (var value in category.Keys)
+            {
+                items.Add(value);
+            }
+        }
+
+        public IEnumerator<string> GetEnumerator()
+        {
+            return ((IEnumerable<string>)items).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable<string>)items).GetEnumerator();
+        }
+    }
+}

--- a/toofz.NecroDancer.Web.Api/Models/Parameters.cs
+++ b/toofz.NecroDancer.Web.Api/Models/Parameters.cs
@@ -1,8 +1,11 @@
 ﻿using System.ComponentModel;
+using System.Web.Http.ModelBinding;
+using toofz.NecroDancer.Web.Api.Infrastructure;
 
 namespace toofz.NecroDancer.Web.Api.Models
 {
-    public class ItemsPagination
+    [ModelBinder(BinderType = typeof(PaginationBinder<ItemsPagination>))]
+    public sealed class ItemsPagination : IPagination
     {
         [MinValue(0)]
         [MaxValue(int.MaxValue)]
@@ -14,7 +17,8 @@ namespace toofz.NecroDancer.Web.Api.Models
         public int limit { get; set; } = 10;
     }
 
-    public class EnemiesPagination
+    [ModelBinder(BinderType = typeof(PaginationBinder<EnemiesPagination>))]
+    public sealed class EnemiesPagination : IPagination
     {
         [MinValue(0)]
         [MaxValue(int.MaxValue)]
@@ -26,7 +30,8 @@ namespace toofz.NecroDancer.Web.Api.Models
         public int limit { get; set; } = 10;
     }
 
-    public class LeaderboardsPagination
+    [ModelBinder(BinderType = typeof(PaginationBinder<LeaderboardsPagination>))]
+    public sealed class LeaderboardsPagination : IPagination
     {
         [MinValue(0)]
         [MaxValue(int.MaxValue)]
@@ -38,7 +43,8 @@ namespace toofz.NecroDancer.Web.Api.Models
         public int limit { get; set; } = 20;
     }
 
-    public class PlayersPagination
+    [ModelBinder(BinderType = typeof(PaginationBinder<PlayersPagination>))]
+    public sealed class PlayersPagination : IPagination
     {
         [MinValue(0)]
         [MaxValue(int.MaxValue)]
@@ -50,7 +56,8 @@ namespace toofz.NecroDancer.Web.Api.Models
         public int limit { get; set; } = 100;
     }
 
-    public class ReplaysPagination
+    [ModelBinder(BinderType = typeof(PaginationBinder<ReplaysPagination>))]
+    public sealed class ReplaysPagination : IPagination
     {
         [MinValue(0)]
         [MaxValue(int.MaxValue)]

--- a/toofz.NecroDancer.Web.Api/toofz.NecroDancer.Web.Api.csproj
+++ b/toofz.NecroDancer.Web.Api/toofz.NecroDancer.Web.Api.csproj
@@ -285,7 +285,9 @@
     </Compile>
     <Compile Include="Infrastructure\LeaderboardCategoryBaseBinder.cs" />
     <Compile Include="Infrastructure\LeaderboardCategoryBinders.cs" />
+    <Compile Include="Infrastructure\PaginationBinder.cs" />
     <Compile Include="IQueryableExtensions.cs" />
+    <Compile Include="Models\IPagination.cs" />
     <Compile Include="Models\LeaderboardCategories.cs" />
     <Compile Include="Models\LeaderboardCategoryBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/toofz.NecroDancer.Web.Api/toofz.NecroDancer.Web.Api.csproj
+++ b/toofz.NecroDancer.Web.Api/toofz.NecroDancer.Web.Api.csproj
@@ -283,7 +283,11 @@
     <Compile Include="Identity\ApplicationDbContext.Views.cs">
       <DependentUpon>ApplicationDbContext.cs</DependentUpon>
     </Compile>
+    <Compile Include="Infrastructure\LeaderboardCategoryBaseBinder.cs" />
+    <Compile Include="Infrastructure\LeaderboardCategoryBinders.cs" />
     <Compile Include="IQueryableExtensions.cs" />
+    <Compile Include="Models\LeaderboardCategories.cs" />
+    <Compile Include="Models\LeaderboardCategoryBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <WCFMetadata Include="Service References\" />
     <Content Include="Service References\Application Insights\ConnectedService.json" />


### PR DESCRIPTION
This PR converts some parameters to use model binding. Using model binding allows for proper separation of concerns and reduces repeated code. It also improves testability. Parameter binding and validation only needs to be tested once instead of for each action that uses them.